### PR TITLE
input fields support lua.Value

### DIFF
--- a/fixtures/any.lua
+++ b/fixtures/any.lua
@@ -1,0 +1,4 @@
+local api = require("test")
+function main(input)
+    return api.toNumbers(input)
+end

--- a/module.go
+++ b/module.go
@@ -162,7 +162,7 @@ func validate(function any) error {
 	// Validate the input
 	for i := 0; i < rt.NumIn(); i++ {
 		v := rt.In(i)
-		if !v.Implements(reflect.TypeOf((*Value)(nil)).Elem()) {
+		if _, ok := typeMap[v]; !ok {
 			return errFuncInput
 		}
 	}

--- a/module.go
+++ b/module.go
@@ -161,8 +161,7 @@ func validate(function any) error {
 
 	// Validate the input
 	for i := 0; i < rt.NumIn(); i++ {
-		v := rt.In(i)
-		if _, ok := typeMap[v]; !ok {
+		if _, ok := typeMap[rt.In(i)]; !ok {
 			return errFuncInput
 		}
 	}

--- a/module.go
+++ b/module.go
@@ -161,7 +161,8 @@ func validate(function any) error {
 
 	// Validate the input
 	for i := 0; i < rt.NumIn(); i++ {
-		if _, ok := typeMap[rt.In(i)]; !ok {
+		v := rt.In(i)
+		if !v.Implements(reflect.TypeOf((*Value)(nil)).Elem()) {
 			return errFuncInput
 		}
 	}

--- a/module_test.go
+++ b/module_test.go
@@ -50,9 +50,9 @@ func errorfunc1(_ Table) (String, error) {
 	return "", errors.New("throwing error")
 }
 
-func hash(s String) (Number, error) {
+func hash(s Value) (Number, error) {
 	h := fnv.New32a()
-	h.Write([]byte(s))
+	h.Write([]byte(s.(String)))
 
 	return Number(h.Sum32()), nil
 }

--- a/module_test.go
+++ b/module_test.go
@@ -30,6 +30,7 @@ func testModule() Module {
 	must(m.Register("enrich", enrich))
 	must(m.Register("error", errorfunc))
 	must(m.Register("error1", errorfunc1))
+	must(m.Register("toNumbers", toNumbers))
 	return m
 }
 
@@ -77,6 +78,15 @@ func enrich(name String, request Table) (Table, error) {
 	request["name"] = name
 	request["age"] = Number(30)
 	return request, nil
+}
+
+func toNumbers(v Value) (Numbers, error) {
+	switch t := v.(type) {
+	case Numbers:
+		return t, nil
+	default:
+		return nil, fmt.Errorf("unsupported type %T", v)
+	}
 }
 
 func Test_Join(t *testing.T) {
@@ -229,4 +239,14 @@ func TestUserdata(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, String("table"), out)
+}
+
+func Test_Any(t *testing.T) {
+	s, err := newScript("fixtures/any.lua")
+	assert.NoError(t, err)
+
+	out, err := s.Run(context.Background(), []float64{1.1, 2.1})
+	assert.NoError(t, err)
+	assert.Equal(t, TypeNumbers, out.Type())
+	assert.Equal(t, []float64{1.1, 2.1}, out.Native())
 }

--- a/value.go
+++ b/value.go
@@ -25,7 +25,20 @@ var (
 	typeBools   = reflect.TypeOf(Bools(nil))
 	typeTable   = reflect.TypeOf(Table(nil))
 	typeArray   = reflect.TypeOf(Array(nil))
+	typeValue   = reflect.TypeOf((*Value)(nil)).Elem()
 )
+
+var typeMap = map[reflect.Type]Type{
+	typeString:  TypeString,
+	typeNumber:  TypeNumber,
+	typeBool:    TypeBool,
+	typeStrings: TypeStrings,
+	typeNumbers: TypeNumbers,
+	typeBools:   TypeBools,
+	typeTable:   TypeTable,
+	typeArray:   TypeArray,
+	typeValue:   TypeValue,
+}
 
 // Type represents a type of the value
 type Type byte
@@ -41,6 +54,7 @@ const (
 	TypeStrings
 	TypeTable
 	TypeArray
+	TypeValue
 )
 
 // Value represents a returned

--- a/value.go
+++ b/value.go
@@ -27,17 +27,6 @@ var (
 	typeArray   = reflect.TypeOf(Array(nil))
 )
 
-var typeMap = map[reflect.Type]Type{
-	typeString:  TypeString,
-	typeNumber:  TypeNumber,
-	typeBool:    TypeBool,
-	typeStrings: TypeStrings,
-	typeNumbers: TypeNumbers,
-	typeBools:   TypeBools,
-	typeTable:   TypeTable,
-	typeArray:   TypeArray,
-}
-
 // Type represents a type of the value
 type Type byte
 


### PR DESCRIPTION
right now function argument cannot be lua.Value and has to be one of the concrete types. I think we should support anything which adheres to the contract of lua.Value